### PR TITLE
added tool to close session

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,20 @@ Captures a screenshot of the current page.
 }
 ```
 
+### close_session
+Closes the current browser session and cleans up resources.
+
+**Parameters:**
+None required
+
+**Example:**
+```json
+{
+  "tool": "close_session",
+  "parameters": {}
+}
+```
+
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@angiejones/mcp-selenium",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@angiejones/mcp-selenium",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angiejones/mcp-selenium",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Selenium WebDriver MCP Server",
   "type": "module",
   "main": "src/lib/server.js",

--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -36,7 +36,7 @@ const getLocator = (by, value) => {
         case 'css': return By.css(value);
         case 'xpath': return By.xpath(value);
         case 'name': return By.name(value);
-        case 'tag': return By.tagName(value);
+        case 'tag': return By.css(value);
         case 'class': return By.className(value);
         default: throw new Error(`Unsupported locator strategy: ${by}`);
     }
@@ -403,6 +403,28 @@ server.tool(
         } catch (e) {
             return {
                 content: [{ type: 'text', text: `Error taking screenshot: ${e.message}` }]
+            };
+        }
+    }
+);
+
+server.tool(
+    "close_session",
+    "closes the current browser session",
+    {},
+    async () => {
+        try {
+            const driver = getDriver();
+            await driver.quit();
+            state.drivers.delete(state.currentSession);
+            const sessionId = state.currentSession;
+            state.currentSession = null;
+            return {
+                content: [{ type: 'text', text: `Browser session ${sessionId} closed` }]
+            };
+        } catch (e) {
+            return {
+                content: [{ type: 'text', text: `Error closing session: ${e.message}` }]
             };
         }
     }


### PR DESCRIPTION
* Implemented the `close_session` tool to close the current browser session, clean up resources, and handle errors.
* Corrected the locator strategy for `tag` from deprecated `By.tagName` to `By.css`.