### PR TITLE
Feature/switch to frame

### DIFF
--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -174,6 +174,7 @@ server.tool(
 );
 
 // Frame/iframe switching tool
+//Contributes by Vishal Bose
 server.tool(
     "switch_to_frame",
     "switches Selenium's context to a frame or iframe by locator, index, or to default content",


### PR DESCRIPTION
This pull request introduces the capability to switch to iframes within the Selenium MCP server.
It enhances the server’s functionality by enabling iframe handling, which is essential for interacting with web elements embedded in nested contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a tool that allows switching the browser context to a specific frame or back to the main document during automated browser sessions. Users can switch by frame locator, index, or return to the default content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->