### PR TITLE
feat: add Internet Explorer mode support for Edge browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A Model Context Protocol (MCP) server implementation for Selenium WebDriver, ena
 
 - Chrome
 - Firefox
-- MS Edge
+- MS Edge (with Internet Explorer mode support)
 
 ## Use with Goose
 
@@ -121,7 +121,7 @@ Launches a browser session.
 **Parameters:**
 - `browser` (required): Browser to launch
   - Type: string
-  - Enum: ["chrome", "firefox"]
+  - Enum: ["chrome", "firefox", "edge"]
 - `options`: Browser configuration options
   - Type: object
   - Properties:
@@ -129,8 +129,12 @@ Launches a browser session.
       - Type: boolean
     - `arguments`: Additional browser arguments
       - Type: array of strings
+    - `ieMode`: Enable Internet Explorer mode for Edge (Edge only)
+      - Type: boolean
 
-**Example:**
+**Examples:**
+
+Chrome browser:
 ```json
 {
   "tool": "start_browser",
@@ -139,6 +143,20 @@ Launches a browser session.
     "options": {
       "headless": true,
       "arguments": ["--no-sandbox"]
+    }
+  }
+}
+```
+
+Edge with Internet Explorer mode (most important feature):
+```json
+{
+  "tool": "start_browser",
+  "parameters": {
+    "browser": "edge",
+    "options": {
+      "ieMode": true,
+      "arguments": ["--disable-web-security"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angiejones/mcp-selenium",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Selenium WebDriver MCP Server",
   "type": "module",
   "main": "src/lib/server.js",


### PR DESCRIPTION
Adds support for IE Mode within Edge. Useful for legacy applications. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Microsoft Edge as a supported browser.
  - Introduced an IE mode option when launching Edge.

- Documentation
  - Updated supported browsers list to include Edge.
  - Added docs for the new IE mode option.
  - Expanded Examples with Chrome and Edge (IE mode) payloads.

- Chores
  - Bumped version to 0.1.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->