### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server implementation for Selenium WebDriver, enabling browser automation through standardized MCP clients.
 
+<a href="https://glama.ai/mcp/servers/@angiejones/mcp-selenium">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@angiejones/mcp-selenium/badge" alt="Selenium MCP server" />
+</a>
+
 ## Video Demo (Click to Watch)
 
 [![Watch the video](https://img.youtube.com/vi/mRV0N8hcgYA/sddefault.jpg)](https://youtu.be/mRV0N8hcgYA)


### PR DESCRIPTION
This PR adds a badge for the [MCP Selenium](https://glama.ai/mcp/servers/@angiejones/mcp-selenium) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@angiejones/mcp-selenium">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@angiejones/mcp-selenium/badge" alt="Selenium MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an MCP Selenium server badge to the README introduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->