### PR TITLE
fix: use By.tagName() for tag locator strategy

### DIFF
--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -37,7 +37,7 @@ const getLocator = (by, value) => {
         case 'css': return By.css(value);
         case 'xpath': return By.xpath(value);
         case 'name': return By.name(value);
-        case 'tag': return By.css(value);
+        case 'tag': return By.tagName(value);
         case 'class': return By.className(value);
         default: throw new Error(`Unsupported locator strategy: ${by}`);
     }


### PR DESCRIPTION
## Summary

The `tag` locator strategy in `getLocator()` was incorrectly using `By.css(value)` instead of `By.tagName(value)`.

## The Problem

When using `find_element` with `by: 'tag'`, the server was delegating to `By.css()` which treats the value as a CSS selector rather than a tag name. While this happened to work for simple tag names like `h1` or `button`, it's semantically incorrect and could produce unexpected results.

## The Fix

```diff
- case 'tag': return By.css(value);
+ case 'tag': return By.tagName(value);
```

This aligns the `tag` strategy with Selenium's native `By.tagName()` method, consistent with how the other strategies map to their corresponding `By` methods (`id` → `By.id()`, `name` → `By.name()`, etc.).

## Testing

Verified with an end-to-end test over MCP stdio (headless Chrome):
- ✅ `find_element` by tag `<h1>` — found
- ✅ `find_element` by tag `<button>` — found  
- ✅ `find_element` by tag `<p>` — found
- ✅ Regression: `css` and `xpath` locators still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Fixed element locator for tag-based selection to work correctly
- Resolved server startup initialization issue to ensure reliable server connection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->