### PR TITLE
fix: resource list compatibility for MCP clients

### DIFF
--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import pkg from 'selenium-webdriver';
@@ -471,7 +471,11 @@ server.tool(
 // Resources
 server.resource(
     "browser-status",
-    new ResourceTemplate("browser-status://current"),
+    "browser-status://current",
+    {
+        description: "Current browser session status",
+        mimeType: "text/plain"
+    },
     async (uri) => ({
         contents: [{
             uri: uri.href,


### PR DESCRIPTION
## Summary

Fixes the MCP resource list bug reported in #33.

### Problem
MCP clients like Kiro call the `resources/list` operation, but the `ResourceTemplate`-based API doesn't support this. This causes:
```
Cannot read properties of undefined (reading 'list')
```

### Fix
Switch from `ResourceTemplate` to a static URI string for the `browser-status` resource. The static URI approach properly supports both `resources/list` and `resources/read` operations.

Also removes the now-unused `ResourceTemplate` import.

### Testing
All 46 existing tests pass.

Fixes #33
Credit: @robbrad for identifying the fix approach in #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified browser-status resource declaration with added metadata including description and MIME type information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->