### PR TITLE
fix: improve switch_to_frame API, add missing docs/tests, fix test reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ Executes JavaScript in the browser and returns the result.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | script | string | Yes | JavaScript code to execute |
+| args | array | No | Arguments to pass to the script (accessible via `arguments[0]`, `arguments[1]`, etc.) |
 
 **Example:**
 ```json
@@ -512,6 +513,17 @@ Executes JavaScript in the browser and returns the result.
   "tool": "execute_script",
   "parameters": {
     "script": "return document.title;"
+  }
+}
+```
+
+**Example with arguments:**
+```json
+{
+  "tool": "execute_script",
+  "parameters": {
+    "script": "return arguments[0] + arguments[1];",
+    "args": [10, 32]
   }
 }
 ```
@@ -577,7 +589,7 @@ None required
 ```
 
 ### switch_to_frame
-Switches focus to an iframe within the page.
+Switches focus to an iframe or frame within the page. Provide either `by`/`value` to locate the frame by element, or `index` to switch by position.
 
 **Parameters:**
 | Parameter | Type | Required | Description |
@@ -585,16 +597,25 @@ Switches focus to an iframe within the page.
 | by | string | No | Locator strategy (id, css, xpath, name, tag, class) |
 | value | string | No | Value for the locator strategy |
 | index | number | No | Frame index (0-based) |
+| timeout | number | No | Max wait time in ms (default: 10000) |
 
-Provide either `by`/`value` to locate the frame by element, or `index` to switch by position. Omit all parameters to switch to the parent frame.
-
-**Example:**
+**Example (by locator):**
 ```json
 {
   "tool": "switch_to_frame",
   "parameters": {
     "by": "id",
     "value": "my-iframe"
+  }
+}
+```
+
+**Example (by index):**
+```json
+{
+  "tool": "switch_to_frame",
+  "parameters": {
+    "index": 0
   }
 }
 ```


### PR DESCRIPTION
## Summary

Follow-up fixes for the 14 new tools merged in the previous PR. Addresses API design issues, missing documentation, and test reliability problems.

### Changes

**`switch_to_frame` — API redesign**

The original overloaded the `by` enum with `"index"`, requiring the frame index to be passed as a string in `value`. Redesigned to use separate optional params:
- `by`/`value` — locate frame by element (standard locator strategies)
- `index` — switch by frame position (a proper number type)

This is cleaner because `"index"` isn't a locator strategy — it's a fundamentally different Selenium operation (`switchTo().frame(int)` vs `switchTo().frame(element)`), and passing a number as a string is error-prone.

**`execute_script` — missing `args` documentation and test coverage**

The `args` parameter was implemented but undocumented in the README and had no test. Added both.

**`close_current_window` — stale session cleanup**

When the last window was closed, the session remained in `state.drivers` with `state.currentSession` still pointing to it, causing confusing errors on subsequent tool calls. Now cleans up both.

**Alert tests — inter-test dependency**

`get_alert_text` left an alert open and the next `accept_alert` test depended on it. Each test now sets up its own preconditions.

### Testing

All 73 tests pass ✅