### PR TITLE
feat: add cookie management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A Model Context Protocol (MCP) server implementation for Selenium WebDriver, ena
 - Take screenshots
 - Upload files
 - Support for headless mode
+- Manage browser cookies (add, get, delete)
 
 ## Supported Browsers
 
@@ -704,6 +705,89 @@ Types text into a browser prompt dialog and accepts it.
   "parameters": {
     "text": "my input"
   }
+}
+```
+
+
+### add_cookie
+Adds a cookie to the current browser session.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| name | string | Yes | Cookie name |
+| value | string | Yes | Cookie value |
+| domain | string | No | Cookie domain |
+| path | string | No | Cookie path (default: /) |
+| secure | boolean | No | Whether the cookie is secure |
+| httpOnly | boolean | No | Whether the cookie is HTTP-only |
+| expiry | number | No | Cookie expiry as Unix timestamp |
+
+**Example:**
+```json
+{
+  "tool": "add_cookie",
+  "parameters": {
+    "name": "session_id",
+    "value": "abc123",
+    "path": "/",
+    "httpOnly": true
+  }
+}
+```
+
+### get_cookies
+Retrieves cookies from the current browser session. Returns all cookies or a specific cookie by name.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| name | string | No | Cookie name to retrieve. If omitted, returns all cookies. |
+
+**Example — get all cookies:**
+```json
+{
+  "tool": "get_cookies",
+  "parameters": {}
+}
+```
+
+**Example — get a specific cookie:**
+```json
+{
+  "tool": "get_cookies",
+  "parameters": {
+    "name": "session_id"
+  }
+}
+```
+
+### delete_cookie
+Deletes cookies from the current browser session. Deletes a specific cookie by name, or all cookies if no name is provided.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| name | string | No | Cookie name to delete. If omitted, deletes all cookies. |
+
+**Example — delete a specific cookie:**
+```json
+{
+  "tool": "delete_cookie",
+  "parameters": {
+    "name": "session_id"
+  }
+}
+```
+
+**Example — delete all cookies:**
+```json
+{
+  "tool": "delete_cookie",
+  "parameters": {}
 }
 ```
 

--- a/test/cookies.test.mjs
+++ b/test/cookies.test.mjs
@@ -1,0 +1,145 @@
+/**
+ * Cookie management tests — add_cookie, get_cookies, delete_cookie.
+ *
+ * Cookies require an HTTP domain (file:// URLs don't support cookies),
+ * so we spin up a tiny local HTTP server for the duration of the suite.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { McpClient, getResponseText } from './mcp-client.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const html = fs.readFileSync(path.join(__dirname, 'fixtures', 'cookies.html'), 'utf-8');
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(html);
+    });
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+describe('Cookie Management', () => {
+  let client;
+  let httpServer;
+  let baseUrl;
+
+  before(async () => {
+    const srv = await startServer();
+    httpServer = srv.server;
+    baseUrl = srv.url;
+
+    client = new McpClient();
+    await client.start();
+    await client.callTool('start_browser', {
+      browser: 'chrome',
+      options: { headless: true, arguments: ['--no-sandbox', '--disable-dev-shm-usage'] },
+    });
+    await client.callTool('navigate', { url: baseUrl });
+  });
+
+  after(async () => {
+    try { await client.callTool('close_session'); } catch { /* ignore */ }
+    await client.stop();
+    await new Promise((resolve) => httpServer.close(resolve));
+  });
+
+  beforeEach(async () => {
+    await client.callTool('delete_cookie', {});
+  });
+
+  describe('add_cookie', () => {
+    it('should add a cookie and verify it was set', async () => {
+      const result = await client.callTool('add_cookie', {
+        name: 'test_cookie',
+        value: 'hello123',
+      });
+      assert.ok(getResponseText(result).includes('Cookie "test_cookie" added'));
+
+      const getResult = await client.callTool('get_cookies', { name: 'test_cookie' });
+      const cookie = JSON.parse(getResponseText(getResult));
+      assert.equal(cookie.name, 'test_cookie');
+      assert.equal(cookie.value, 'hello123');
+    });
+
+    it('should respect optional properties', async () => {
+      await client.callTool('add_cookie', {
+        name: 'opts_cookie',
+        value: 'secret',
+        path: '/',
+        httpOnly: true,
+      });
+
+      const getResult = await client.callTool('get_cookies', { name: 'opts_cookie' });
+      const cookie = JSON.parse(getResponseText(getResult));
+      assert.equal(cookie.path, '/');
+      assert.equal(cookie.httpOnly, true);
+    });
+  });
+
+  describe('get_cookies', () => {
+    it('should return all cookies as an array', async () => {
+      await client.callTool('add_cookie', { name: 'a', value: '1' });
+      await client.callTool('add_cookie', { name: 'b', value: '2' });
+
+      const result = await client.callTool('get_cookies', {});
+      const cookies = JSON.parse(getResponseText(result));
+      assert.ok(Array.isArray(cookies));
+      const names = cookies.map(c => c.name);
+      assert.ok(names.includes('a') && names.includes('b'));
+    });
+
+    it('should return empty array when no cookies exist', async () => {
+      const result = await client.callTool('get_cookies', {});
+      const cookies = JSON.parse(getResponseText(result));
+      assert.equal(cookies.length, 0);
+    });
+
+    it('should error when a named cookie is not found', async () => {
+      const result = await client.callTool('get_cookies', { name: 'ghost' });
+      assert.strictEqual(result.isError, true);
+      assert.ok(getResponseText(result).includes('not found'));
+    });
+  });
+
+  describe('delete_cookie', () => {
+    it('should delete a specific cookie and leave others', async () => {
+      await client.callTool('add_cookie', { name: 'delete_me', value: 'bye' });
+      await client.callTool('add_cookie', { name: 'keep_me', value: 'stay' });
+
+      await client.callTool('delete_cookie', { name: 'delete_me' });
+
+      const gone = await client.callTool('get_cookies', { name: 'delete_me' });
+      assert.strictEqual(gone.isError, true);
+
+      const kept = JSON.parse(getResponseText(
+        await client.callTool('get_cookies', { name: 'keep_me' })
+      ));
+      assert.equal(kept.name, 'keep_me');
+    });
+
+    it('should delete all cookies when no name is provided', async () => {
+      await client.callTool('add_cookie', { name: 'x', value: '1' });
+      await client.callTool('add_cookie', { name: 'y', value: '2' });
+
+      const result = await client.callTool('delete_cookie', {});
+      assert.ok(getResponseText(result).includes('All cookies deleted'));
+
+      const cookies = JSON.parse(getResponseText(
+        await client.callTool('get_cookies', {})
+      ));
+      assert.equal(cookies.length, 0);
+    });
+  });
+});

--- a/test/fixtures/cookies.html
+++ b/test/fixtures/cookies.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Cookie Test Page</title></head>
+<body><h1 id="title">Cookie Test Page</h1></body>
+</html>

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -25,7 +25,7 @@ describe('MCP Server', () => {
     assert.ok(tools.length > 0, 'Server should have tools registered');
   });
 
-  it('should register all 28 expected tools', async () => {
+  it('should register all expected tools', async () => {
     const tools = await client.listTools();
     const names = tools.map((t) => t.name);
 
@@ -58,6 +58,9 @@ describe('MCP Server', () => {
       'dismiss_alert',
       'get_alert_text',
       'send_alert_text',
+      'add_cookie',
+      'get_cookies',
+      'delete_cookie',
     ];
 
     for (const name of expected) {


### PR DESCRIPTION
Adds three new MCP tools for browser cookie management, as requested in #19.

## New Tools

- **`add_cookie`** — Set a cookie with required `name`/`value` and optional `domain`, `path`, `secure`, `httpOnly`, `expiry`
- **`get_cookies`** — Retrieve all cookies or a specific one by name
- **`delete_cookie`** — Delete a specific cookie by name, or all cookies

## Changes

- `src/lib/server.js` — 3 new cookie tools following existing patterns
- `test/cookies.test.mjs` — 7 tests with a local HTTP server (cookies don't work on `file://` URLs)
- `test/fixtures/cookies.html` — minimal fixture page
- `test/server.test.mjs` — added cookie tools to expected tool list
- `README.md` — feature bullet + full tool documentation

## Notes

- Chrome's `getCookie()` throws `no such cookie` instead of returning `null`, so `get_cookies` handles that gracefully
- All 82 tests pass (including Safari support from main)

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser cookie management capabilities including creating, retrieving, and deleting cookies with support for standard cookie properties (domain, path, secure, httpOnly, expiry).

* **Documentation**
  * Updated README with comprehensive cookie management documentation and usage examples.

* **Tests**
  * Added comprehensive test suite for cookie operations with real HTTP context validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->