### PR TITLE
server instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angiejones/mcp-selenium",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Selenium WebDriver MCP Server",
   "type": "module",
   "main": "src/lib/server.js",

--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -17,11 +17,10 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const { version } = require('../../package.json');
 
-const server = new McpServer({
-    name: "MCP Selenium",
-    version,
-    instructions: "To understand the current page state, read the accessibility://current resource. It provides a structured accessibility tree that's faster and more reliable for finding element locators."
-});
+const server = new McpServer(
+    { name: "MCP Selenium", version },
+    { instructions: "To understand the current page state, read the accessibility://current resource. It provides a structured accessibility tree that's faster and more reliable for finding element locators." }
+);
 
 // BiDi imports — loaded dynamically to avoid hard failures if not available
 let LogInspector, Network;

--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -19,7 +19,8 @@ const { version } = require('../../package.json');
 
 const server = new McpServer({
     name: "MCP Selenium",
-    version
+    version,
+    instructions: "To understand the current page state, read the accessibility://current resource. It provides a structured accessibility tree that's faster and more reliable for finding element locators."
 });
 
 // BiDi imports — loaded dynamically to avoid hard failures if not available
@@ -436,7 +437,7 @@ server.registerTool(
 server.registerTool(
     "take_screenshot",
     {
-        description: "captures a screenshot of the current page",
+        description: "captures a screenshot of the current page. Prefer using the accessibility://current resource for understanding page content. Use screenshots only when visual layout matters.",
         inputSchema: {
         outputPath: z.string().optional().describe("Optional path where to save the screenshot. If not provided, returns an image/png content block.")
     }


### PR DESCRIPTION
nudge agent to use accessibility tree over screenshots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.2.2

* **New Features**
  * Server configuration now accepts an optional instructions field to allow custom guidance for instances

* **Documentation**
  * Tool usage guidance clarified with recommendations on when to rely on accessibility metadata versus screenshots and best-practice notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->